### PR TITLE
非同期メソッドにキャンセルトークンを追加

### DIFF
--- a/Mikaboshi.Locapos/Groups.cs
+++ b/Mikaboshi.Locapos/Groups.cs
@@ -1,4 +1,5 @@
 ﻿using Mikaboshi.Locapos.Response;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Mikaboshi.Locapos
@@ -26,14 +27,15 @@ namespace Mikaboshi.Locapos
         /// <summary>
         /// 新しくグループを作成します。
         /// </summary>
+        /// <param name="cancellationToken">キャンセルトークン</param>
         /// <returns>グループのハッシュが含まれるレスポンス情報。</returns>
-        public async Task<GroupHashResponse> New()
+        public async Task<GroupHashResponse> New(CancellationToken cancellationToken = default)
         {
             this.client.CheckToken();
 
             var http = LocaposClientInternal.GetHttpClient(this.client.ClientToken!);
             var request = LocaposClientInternal.CreateGetRequest(this.NewUri);
-            var response = await http.SendAsync(request);
+            var response = await http.SendAsync(request, cancellationToken);
             var result = new GroupHashResponse();
             await result.SetResponseAsync(response);
 

--- a/Mikaboshi.Locapos/Locations.cs
+++ b/Mikaboshi.Locapos/Locations.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Mikaboshi.Locapos
@@ -31,8 +32,9 @@ namespace Mikaboshi.Locapos
         /// <param name="heading">送信する移動時の向き。真北を 0 とし、0 - 359 または -180 - 0 - 180 のどれかで指定ができ、また null を指定した場合は、相手には前の位置からの推測で表示されます。</param>
         /// <param name="privatePost">Locapos の公開地図に表示するかどうか。</param>
         /// <param name="groupId">任意グループに対して送信する場合はその ID を指定します。</param>
+        /// <param name="cancellationToken">キャンセルトークン</param>
         /// <returns></returns>
-        public async Task<BaseResponse> UpdateAsync(double latitude, double longitude, double? heading = null, bool privatePost = false, string groupId = "")
+        public async Task<BaseResponse> UpdateAsync(double latitude, double longitude, double? heading = null, bool privatePost = false, string groupId = "", CancellationToken cancellationToken = default)
         {
             this.client.CheckToken();
 
@@ -50,7 +52,7 @@ namespace Mikaboshi.Locapos
             var contents = new FormUrlEncodedContent(contentsDict);
             var request = await LocaposClientInternal.CreatePostRequestAsync(this.UpdateUri, contents, true);
 
-            var response = await http.SendAsync(request);
+            var response = await http.SendAsync(request, cancellationToken);
             var result = new BaseResponse();
             await result.SetResponseAsync(response);
 

--- a/Mikaboshi.Locapos/Users.cs
+++ b/Mikaboshi.Locapos/Users.cs
@@ -1,7 +1,8 @@
-﻿using Mikaboshi.Locapos.Response;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
+using Mikaboshi.Locapos.Response;
 
 namespace Mikaboshi.Locapos
 {
@@ -30,15 +31,16 @@ namespace Mikaboshi.Locapos
         /// 現在アクティブなユーザーの情報を取得します。<paramref name="groupId"/> を使用して、該当するグループの絞り込みをおこないます。
         /// </summary>
         /// <param name="groupId">指定した場合、該当するグループ ID でアクティブなユーザー一覧を取得します。</param>
+        /// <param name="cancellationToken"> キャンセルトークン</param>
         /// <returns></returns>
-        public async Task<UsersShowResponse> Show(string groupId = "")
+        public async Task<UsersShowResponse> Show(string groupId = "", CancellationToken cancellationToken = default)
         {
             this.client.CheckToken();
 
             var http = LocaposClientInternal.GetHttpClient(this.client.ClientToken!);
             var request = LocaposClientInternal.CreateGetRequest(this.ShowUri +
                 (!string.IsNullOrWhiteSpace(groupId) ? "?key=" + groupId : string.Empty));
-            var response = await http.SendAsync(request);
+            var response = await http.SendAsync(request, cancellationToken);
             var result = new UsersShowResponse();
             await result.SetResponseAsync(response);
 
@@ -48,14 +50,15 @@ namespace Mikaboshi.Locapos
         /// <summary>
         /// 自分自身の情報を取得します。
         /// </summary>
+        /// <param name="cancellationToken"> キャンセルトークン</param>
         /// <returns></returns>
-        public async Task<UsersMeResponse> Me()
+        public async Task<UsersMeResponse> Me(CancellationToken cancellationToken = default)
         {
             this.client.CheckToken();
 
             var http = LocaposClientInternal.GetHttpClient(this.client.ClientToken!);
             var request = LocaposClientInternal.CreateGetRequest(this.MeUri);
-            var response = await http.SendAsync(request);
+            var response = await http.SendAsync(request, cancellationToken);
             var result = new UsersMeResponse();
             await result.SetResponseAsync(response);
 
@@ -65,21 +68,22 @@ namespace Mikaboshi.Locapos
         /// <summary>
         /// 自分自身を示す暗黙的なグループ ハッシュを取得します。
         /// </summary>
+        /// <param name="cancellationToken"> キャンセルトークン</param>
         /// <returns></returns>
-        public async Task<GroupHashResponse> Share()
+        public async Task<GroupHashResponse> Share(CancellationToken cancellationToken = default)
         {
             this.client.CheckToken();
 
             var http = LocaposClientInternal.GetHttpClient(this.client.ClientToken!);
             var request = LocaposClientInternal.CreateGetRequest(this.ShareUri);
-            var response = await http.SendAsync(request);
+            var response = await http.SendAsync(request, cancellationToken);
             var result = new GroupHashResponse();
             await result.SetResponseAsync(response);
 
             return result;
         }
 
-        public async Task<BaseResponse> Update(string screenName)
+        public async Task<BaseResponse> Update(string screenName, CancellationToken cancellationToken = default)
         {
             this.client.CheckToken();
 
@@ -92,7 +96,7 @@ namespace Mikaboshi.Locapos
             var content = new FormUrlEncodedContent(contentDict);
 
             var request = await LocaposClientInternal.CreatePostRequestAsync(this.UpdateNameUri, content);
-            var response = await http.SendAsync(request);
+            var response = await http.SendAsync(request, cancellationToken);
             var result = new BaseResponse();
             await result.SetResponseAsync(response);
 


### PR DESCRIPTION
`Groups.cs`、`Locations.cs`、`Users.cs` の各ファイルで、非同期メソッドに `CancellationToken` パラメータを追加しました。これにより、呼び出し元がメソッドの実行をキャンセルできるようになります。具体的には、`New`、`UpdateAsync`、`Show`、`Me`、`Share`、および `Update` メソッドが変更され、HTTP リクエストを送信する際に `SendAsync` メソッドに `cancellationToken` を渡すように修正されています。これにより、リクエストがキャンセル可能になり、より柔軟な非同期処理が実現されます。